### PR TITLE
Fix bug in point distribution for submit_exercise

### DIFF
--- a/contracts/Evaluator.cairo
+++ b/contracts/Evaluator.cairo
@@ -495,9 +495,6 @@ func submit_exercise{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_che
 		# player has validated
 		validate_exercice(sender_address, 0)
 		# Sending points
-		# setup points
-		distribute_points(sender_address, 2)
-		# Deploying contract points
 		distribute_points(sender_address, 2)
 
 	end


### PR DESCRIPTION
Previously `submit_exercise()` would distribute 4 points for submitting an exercise. I noticed this because I earned 6 points after completing exercise 1 when I should have received 4 points total.

Ref: https://github.com/starknet-edu/starknet-erc721/blob/cf450ae55057f48c5108cfd30adb5fbf3f6df0c4/README.md?plain=1#L183-L184