### PR TITLE
Update Evaluator.cairo

### DIFF
--- a/contracts/Evaluator.cairo
+++ b/contracts/Evaluator.cairo
@@ -623,8 +623,7 @@ func submit_exercise{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_che
         # player has validated
         validate_exercice(sender_address, 0)
         # Sending points
-        # setup points
-        distribute_points(sender_address, 2)
+        
         # Deploying contract points
         distribute_points(sender_address, 2)
         return ()


### PR DESCRIPTION
In function submit_exercise, instead of 2 points, 4 points are being sent to sender_address as distribute_points is called twice.