### PR TITLE
Fixed OpenZeppelin imports

### DIFF
--- a/contracts/token/ERC721/ERC721.cairo
+++ b/contracts/token/ERC721/ERC721.cairo
@@ -3,21 +3,7 @@
 from starkware.cairo.common.cairo_builtins import HashBuiltin, SignatureBuiltin
 from starkware.cairo.common.uint256 import Uint256
 
-from openzeppelin.token.erc721.library import (
-    ERC721_name,
-    ERC721_symbol,
-    ERC721_balanceOf,
-    ERC721_ownerOf,
-    ERC721_getApproved,
-    ERC721_isApprovedForAll,
-    ERC721_mint,
-    ERC721_burn,
-    ERC721_initializer,
-    ERC721_approve,
-    ERC721_setApprovalForAll,
-    ERC721_transferFrom,
-    ERC721_safeTransferFrom,
-)
+from openzeppelin.token.erc721.library import ERC721
 
 #
 # Constructor
@@ -27,10 +13,10 @@ from openzeppelin.token.erc721.library import (
 func constructor{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
     name : felt, symbol : felt, to_ : felt
 ):
-    ERC721_initializer(name, symbol)
+    ERC721.initializer(name, symbol)
     let to = to_
     let token_id : Uint256 = Uint256(1, 0)
-    ERC721_mint(to, token_id)
+    ERC721._mint(to, token_id)
     return ()
 end
 
@@ -40,13 +26,13 @@ end
 
 @view
 func name{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}() -> (name : felt):
-    let (name) = ERC721_name()
+    let (name) = ERC721.name()
     return (name)
 end
 
 @view
 func symbol{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}() -> (symbol : felt):
-    let (symbol) = ERC721_symbol()
+    let (symbol) = ERC721.symbol()
     return (symbol)
 end
 
@@ -54,7 +40,7 @@ end
 func balanceOf{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(owner : felt) -> (
     balance : Uint256
 ):
-    let (balance : Uint256) = ERC721_balanceOf(owner)
+    let (balance : Uint256) = ERC721.balance_of(owner)
     return (balance)
 end
 
@@ -62,7 +48,7 @@ end
 func ownerOf{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
     token_id : Uint256
 ) -> (owner : felt):
-    let (owner : felt) = ERC721_ownerOf(token_id)
+    let (owner : felt) = ERC721.owner_of(token_id)
     return (owner)
 end
 
@@ -70,7 +56,7 @@ end
 func getApproved{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
     token_id : Uint256
 ) -> (approved : felt):
-    let (approved : felt) = ERC721_getApproved(token_id)
+    let (approved : felt) = ERC721.get_approved(token_id)
     return (approved)
 end
 
@@ -78,7 +64,7 @@ end
 func isApprovedForAll{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
     owner : felt, operator : felt
 ) -> (is_approved : felt):
-    let (is_approved : felt) = ERC721_isApprovedForAll(owner, operator)
+    let (is_approved : felt) = ERC721.is_approved_for_all(owner, operator)
     return (is_approved)
 end
 
@@ -90,7 +76,7 @@ end
 func approve{pedersen_ptr : HashBuiltin*, syscall_ptr : felt*, range_check_ptr}(
     to : felt, token_id : Uint256
 ):
-    ERC721_approve(to, token_id)
+    ERC721.approve(to, token_id)
     return ()
 end
 
@@ -98,7 +84,7 @@ end
 func setApprovalForAll{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
     operator : felt, approved : felt
 ):
-    ERC721_setApprovalForAll(operator, approved)
+    ERC721.set_approval_for_all(operator, approved)
     return ()
 end
 
@@ -106,7 +92,7 @@ end
 func transferFrom{pedersen_ptr : HashBuiltin*, syscall_ptr : felt*, range_check_ptr}(
     _from : felt, to : felt, token_id : Uint256
 ):
-    ERC721_transferFrom(_from, to, token_id)
+    ERC721.transfer_from(_from, to, token_id)
     return ()
 end
 
@@ -114,6 +100,6 @@ end
 func safeTransferFrom{pedersen_ptr : HashBuiltin*, syscall_ptr : felt*, range_check_ptr}(
     _from : felt, to : felt, token_id : Uint256, data_len : felt, data : felt*
 ):
-    ERC721_safeTransferFrom(_from, to, token_id, data_len, data)
+    ERC721.safe_transfer_from(_from, to, token_id, data_len, data)
     return ()
 end

--- a/contracts/token/ERC721/ERC721_Metadata_base.cairo
+++ b/contracts/token/ERC721/ERC721_Metadata_base.cairo
@@ -4,9 +4,9 @@ from starkware.cairo.common.alloc import alloc
 from starkware.cairo.common.cairo_builtins import HashBuiltin, SignatureBuiltin
 from starkware.cairo.common.uint256 import Uint256
 
-from openzeppelin.token.erc721.library import _exists
+from openzeppelin.token.erc721.library import ERC721
 
-from openzeppelin.introspection.ERC165 import ERC165_register_interface
+from openzeppelin.introspection.ERC165 import ERC165
 
 from contracts.utils.ShortString import uint256_to_ss
 from contracts.utils.Array import concat_arr
@@ -34,7 +34,7 @@ end
 func ERC721_Metadata_initializer{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
     ):
     # register IERC721_Metadata
-    ERC165_register_interface(0x5b5e139f)
+    ERC165.register_interface(0x5b5e139f)
     return ()
 end
 
@@ -43,7 +43,7 @@ func ERC721_Metadata_tokenURI{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, 
 ) -> (token_uri_len : felt, token_uri : felt*):
     alloc_locals
 
-    let (exists) = _exists(token_id)
+    let (exists) = ERC721._exists(token_id)
     assert exists = 1
 
     let (local base_token_uri) = alloc()

--- a/contracts/token/ERC721/ERC721_metadata.cairo
+++ b/contracts/token/ERC721/ERC721_metadata.cairo
@@ -3,21 +3,7 @@
 from starkware.cairo.common.cairo_builtins import HashBuiltin, SignatureBuiltin
 from starkware.cairo.common.uint256 import Uint256
 
-from openzeppelin.token.erc721.library import (
-    ERC721_name,
-    ERC721_symbol,
-    ERC721_balanceOf,
-    ERC721_ownerOf,
-    ERC721_getApproved,
-    ERC721_isApprovedForAll,
-    ERC721_mint,
-    ERC721_burn,
-    ERC721_initializer,
-    ERC721_approve,
-    ERC721_setApprovalForAll,
-    ERC721_transferFrom,
-    ERC721_safeTransferFrom,
-)
+from openzeppelin.token.erc721.library import ERC721
 
 from contracts.token.ERC721.ERC721_Metadata_base import (
     ERC721_Metadata_initializer,
@@ -25,14 +11,9 @@ from contracts.token.ERC721.ERC721_Metadata_base import (
     ERC721_Metadata_setBaseTokenURI,
 )
 
-from openzeppelin.introspection.ERC165 import ERC165_supports_interface
+from openzeppelin.introspection.ERC165 import ERC165
 
-from openzeppelin.access.ownable import (
-    Ownable_initializer,
-    Ownable_only_owner,
-    Ownable_get_owner,
-    Ownable_transfer_ownership,
-)
+from openzeppelin.access.ownable import Ownable
 
 #
 # Constructor
@@ -47,9 +28,9 @@ func constructor{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_p
     base_token_uri : felt*,
     token_uri_suffix : felt,
 ):
-    ERC721_initializer(name, symbol)
+    ERC721.initializer(name, symbol)
     ERC721_Metadata_initializer()
-    Ownable_initializer(owner)
+    Ownable.initializer(owner)
     ERC721_Metadata_setBaseTokenURI(base_token_uri_len, base_token_uri, token_uri_suffix)
     return ()
 end
@@ -62,7 +43,7 @@ end
 func getOwner{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}() -> (
     owner : felt
 ):
-    let (owner) = Ownable_get_owner()
+    let (owner) = Ownable.owner()
     return (owner=owner)
 end
 
@@ -70,19 +51,19 @@ end
 func supportsInterface{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
     interface_id : felt
 ) -> (success : felt):
-    let (success) = ERC165_supports_interface(interface_id)
+    let (success) = ERC165.supports_interface(interface_id)
     return (success)
 end
 
 @view
 func name{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}() -> (name : felt):
-    let (name) = ERC721_name()
+    let (name) = ERC721.name()
     return (name)
 end
 
 @view
 func symbol{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}() -> (symbol : felt):
-    let (symbol) = ERC721_symbol()
+    let (symbol) = ERC721.symbol()
     return (symbol)
 end
 
@@ -90,7 +71,7 @@ end
 func balanceOf{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(owner : felt) -> (
     balance : Uint256
 ):
-    let (balance : Uint256) = ERC721_balanceOf(owner)
+    let (balance : Uint256) = ERC721.balance_of(owner)
     return (balance)
 end
 
@@ -98,7 +79,7 @@ end
 func ownerOf{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
     token_id : Uint256
 ) -> (owner : felt):
-    let (owner : felt) = ERC721_ownerOf(token_id)
+    let (owner : felt) = ERC721.owner_of(token_id)
     return (owner)
 end
 
@@ -106,7 +87,7 @@ end
 func getApproved{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
     token_id : Uint256
 ) -> (approved : felt):
-    let (approved : felt) = ERC721_getApproved(token_id)
+    let (approved : felt) = ERC721.get_approved(token_id)
     return (approved)
 end
 
@@ -114,7 +95,7 @@ end
 func isApprovedForAll{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
     owner : felt, operator : felt
 ) -> (is_approved : felt):
-    let (is_approved : felt) = ERC721_isApprovedForAll(owner, operator)
+    let (is_approved : felt) = ERC721.is_approved_for_all(owner, operator)
     return (is_approved)
 end
 
@@ -134,7 +115,7 @@ end
 func approve{pedersen_ptr : HashBuiltin*, syscall_ptr : felt*, range_check_ptr}(
     to : felt, token_id : Uint256
 ):
-    ERC721_approve(to, token_id)
+    ERC721.approve(to, token_id)
     return ()
 end
 
@@ -142,7 +123,7 @@ end
 func setApprovalForAll{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
     operator : felt, approved : felt
 ):
-    ERC721_setApprovalForAll(operator, approved)
+    ERC721.set_approval_for_all(operator, approved)
     return ()
 end
 
@@ -150,7 +131,7 @@ end
 func transferFrom{pedersen_ptr : HashBuiltin*, syscall_ptr : felt*, range_check_ptr}(
     _from : felt, to : felt, token_id : Uint256
 ):
-    ERC721_transferFrom(_from, to, token_id)
+    ERC721.transfer_from(_from, to, token_id)
     return ()
 end
 
@@ -158,7 +139,7 @@ end
 func safeTransferFrom{pedersen_ptr : HashBuiltin*, syscall_ptr : felt*, range_check_ptr}(
     _from : felt, to : felt, token_id : Uint256, data_len : felt, data : felt*
 ):
-    ERC721_safeTransferFrom(_from, to, token_id, data_len, data)
+    ERC721.safe_transfer_from(_from, to, token_id, data_len, data)
     return ()
 end
 
@@ -166,7 +147,7 @@ end
 func setTokenURI{pedersen_ptr : HashBuiltin*, syscall_ptr : felt*, range_check_ptr}(
     base_token_uri_len : felt, base_token_uri : felt*, token_uri_suffix : felt
 ):
-    Ownable_only_owner()
+    Ownable.assert_only_owner()
     ERC721_Metadata_setBaseTokenURI(base_token_uri_len, base_token_uri, token_uri_suffix)
     return ()
 end
@@ -175,15 +156,15 @@ end
 func mint{pedersen_ptr : HashBuiltin*, syscall_ptr : felt*, range_check_ptr}(
     to : felt, token_id : Uint256
 ):
-    Ownable_only_owner()
-    ERC721_mint(to, token_id)
+    Ownable.assert_only_owner()
+    ERC721._mint(to, token_id)
     return ()
 end
 
 @external
 func burn{pedersen_ptr : HashBuiltin*, syscall_ptr : felt*, range_check_ptr}(token_id : Uint256):
-    Ownable_only_owner()
-    ERC721_burn(token_id)
+    Ownable.assert_only_owner()
+    ERC721._burn(token_id)
     return ()
 end
 
@@ -192,6 +173,6 @@ func transferOwnership{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_c
     new_owner : felt
 ) -> (new_owner : felt):
     # Ownership check is handled by this function
-    Ownable_transfer_ownership(new_owner)
+    Ownable.transfer_ownership(new_owner)
     return (new_owner=new_owner)
 end


### PR DESCRIPTION
When trying to compile `ERC721.cairo` I get the following error:

```shell
$ starknet-compile contracts/token/ERC721/ERC721.cairo --output artifacts/ERC721.json
>>>
contracts/token/ERC721/ERC721.cairo:9:5: Cannot import 'ERC721_balanceOf' from 'openzeppelin.token.erc721.library'.
    ERC721_balanceOf,
    ^**************^
```

The problem is that in the new version of `openzeppelin-cairo-contracts` they are exporting the ERC721 functionality under the `ERC721` namespace instead of mimicking a namespace using a naming convention. This problem is affecting multiple contracts, not only `ERC721.cairo`.

Additionally, OpenZeppelin is now using snake case instead of camel case for naming the exported functions. 

This PR takes care of fixing both problems.